### PR TITLE
fix lame library link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The software used to generate Morse Code Ninja practice sets as found on
 These must be installed and available in your Shell's PATH.
 * [ebook2cw](https://fkurz.net/ham/ebook2cw.html)
 * [ffmpeg](https://ffmpeg.org)
-* [lame](https://ffmpeg.org)
+* [lame](https://lame.sourceforge.io/)
 * [Perl 5](https://www.perl.org)
 * [Python 3](https://www.python.org)
 * [Boto3](https://aws.amazon.com/sdk-for-python/)


### PR DESCRIPTION
I noticed that the link to the lame library was the same as the ffmpeg. I hope the site I pointed to is the right one.