### PR TITLE
Fixes running on newer versions of Perl

### DIFF
--- a/render.pl
+++ b/render.pl
@@ -365,7 +365,10 @@ foreach(@sentences) {
           my $counter = sprintf("%05d",$count);
           my $fork_count = 0;
 
-          sub uniq { keys { map { $_ => 1 } @_ } };
+          sub uniq {
+            my %seen;
+            return grep { !$seen{$_}++ } @_;
+          }
 
           my @render_speeds = @speeds;
           if($speed_racing == 1) {


### PR DESCRIPTION
Specifically fixed a "uniq" function that returned the unique
entries in an array. The cryptic function was using an
experimental "keys on scalar" feature that is now forbidden
in newer versions of perl.

I replaced the uniq function with something less crtypic
and that works on older and newer versions of perl.

Tested on Perl 5.32.1 and 5.18.4