### PR TITLE
Use AWS_ACCESS_KEY_ID instead of AWS_KEY_ID in text2speech.py

### DIFF
--- a/text2speech.py
+++ b/text2speech.py
@@ -27,8 +27,8 @@ print("Cache directory: " + cache_directory)
 separator = "="
 aws_properties = {}
 
-if "AWS_KEY_ID" in environ and "AWS_SECRET_ACCESS_KEY" in environ:
-    aws_properties['aws_access_key_id'] = environ['AWS_KEY_ID']
+if "AWS_ACCESS_KEY_ID" in environ and "AWS_SECRET_ACCESS_KEY" in environ:
+    aws_properties['aws_access_key_id'] = environ['AWS_ACCESS_KEY_ID']
     aws_properties['aws_secret_access_key'] = environ['AWS_SECRET_ACCESS_KEY']
 else:
     try:


### PR DESCRIPTION
I was testing the code without setting my keys in the `aws.config` instead using my session keys from env vars to be detected. This failed to work. It looks like are correctly set in `text2speech.py` however, the detection of env vars are looking for `AWS_KEY_ID` rather than `AWS_ACCESS_KEY_ID`.

According to the [AWS CLI guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), the environment vars are conventionally set to `AWS_ACCESS_KEY_ID`. 