### PR TITLE
Encapsulate execution environment using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+RUN apt update
+RUN apt -y install lame ffmpeg ebook2cw
+RUN pip install boto3
+
+RUN mkdir -p /opt/morse-code-ninja
+WORKDIR /opt/morse-code-ninja

--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ multiple copies are executing at the same time using the same output directory.
 Be aware that the script can create a huge number of temporary files, which is proportional to the input file. Some types of filesystems will deal with this better than others.
 
 This set of scripts works on Linux and macOS.
+
+# Docker Usage
+This usage limits the required software to:
+- [Docker](https://www.docker.com/get-started/) 
+- [AWS Cloud Setup](#cloud-setup)
+
+To run
+```
+./morse-code-ninja.sh -i example.txt
+```
+
+The script `morse-code-ninja.sh` wraps the docker compose command passing all arguments to the dockerized `render.pl` 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  app:
+    container_name: morse-code-ninja
+    build: .
+    volumes:
+      - .:/opt/morse-code-ninja/
+    environment:
+      - AWS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}

--- a/morse-code-ninja.sh
+++ b/morse-code-ninja.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose run --rm app perl render.pl "$@"


### PR DESCRIPTION
Created a Dockerfile and wrapper shell script to make this quickly executable for users without having to think about installation cross platform, and debugging any dependency installs, keeping the setup minimized to just:

- Setup Docker
- Setup AWS

The goal was to help users that are aiming to make custom practice files easier without too much of a developer deep dive keeping up with the dependencies to install and which versions. I took a stab at updating the README but feel free to tweak to how you prefer to communicate it.

Basically, as a user I didn't want to dig too much into "how to setup" and wanted to "just use it" with the least effort to get it up and running :)