### PR TITLE
tts support for romanian

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ you may define AWS_KEY_ID and AWS_SECRET_ACCESS_KEY as environmental variables.
     perl render.pl -i file [-o directory] [-c directory] [-s speeds] [-p pitch] [-pr]
                    [-m max processes] [-z 1] [-rr 1] [--test] [-l word limit]
                    [--norepeat] [--nospoken] [--nocourtesytone] [-e NEURAL | STANDARD] 
-                   [--sm] [--ss] [--sv] [-x] [--lang ENGLISH | SWEDISH]
+                   [--sm] [--ss] [--sv] [-x] [--lang ENGLISH | SWEDISH | ROMANIAN]
 
 Uses AWS Polly and requires valid credentials in the aws.properties file.<br/><br/>
+
+For `-l ROMANIAN`, remember to use `-e STANDARD`. Neural languages do not sound as rough as standard ones.
 
 #### OPTIONS:
 

--- a/render.pl
+++ b/render.pl
@@ -12,6 +12,7 @@ use File::Spec;
 use Getopt::Long;
 use Digest::SHA qw(sha256_hex sha256_base64);
 use POSIX;
+use Encode qw(encode_utf8);
 
 my @speeds;
 sub print_usage;
@@ -62,7 +63,8 @@ my @random_tones = (500, 550, 600, 650, 700, 750, 800, 850, 900);
 
 # set default value for speeds here as it is too complex to do it inside the GetOptions call above
 my $speedSize = @speeds;
-@speeds = ($speedSize > 0) ? @speeds : ("15", "17", "20", "22", "25", "28", "30", "35", "40", "45", "50");
+ @speeds = ($speedSize > 0) ? @speeds : ("15", "17", "20", "22", "25", "28", "30", "32", "35", "40", "45", "50");
+#@speeds = ($speedSize > 0) ? @speeds : ("15", "20");
 
 if (! -d "$output_directory") {
   mkdir "$output_directory";
@@ -82,6 +84,10 @@ if($lang eq "SWEDISH") {
 if($lang eq "GERMAN") {
   $lower_lang_chars_regex = "a-züäöß";
   $upper_lang_chars_regex = "A-ZÜÄÖß";
+}
+if($lang eq "ROMANIAN") {
+  $lower_lang_chars_regex = "a-zâăîșț";
+  $upper_lang_chars_regex = "A-ZÂĂÎȘȚ";
 }
 
 binmode(STDOUT, ":encoding(UTF-8)");
@@ -408,7 +414,8 @@ foreach(@sentences) {
         $cached_filename = "${lang}-standard-";
       }
 
-      $cached_filename .= $text_to_speech_engine . "-" . sha256_hex($sentence) . ".mp3";
+      use Encode qw(encode_utf8);
+      $cached_filename .= $text_to_speech_engine . "-" . sha256_hex(encode_utf8($sentence)) . ".mp3";
       $cached_filename = $cache_directory . $cached_filename;
 
       return $cached_filename;
@@ -581,7 +588,8 @@ foreach(@sentences) {
             sub get_cached_filename {
               my ($ebookCmdBase, $morse_text) = @_;
 
-              my $cached_file_hash = sha256_base64($ebookCmdBase . $morse_text);
+	      use Encode qw(encode_utf8);
+	      my $cached_file_hash = sha256_base64(encode_utf8($ebookCmdBase . $morse_text));
               $cached_file_hash =~ s/\///g;
               my $cached_file = $cached_file_hash . ".mp3";
 

--- a/render.pl
+++ b/render.pl
@@ -63,8 +63,7 @@ my @random_tones = (500, 550, 600, 650, 700, 750, 800, 850, 900);
 
 # set default value for speeds here as it is too complex to do it inside the GetOptions call above
 my $speedSize = @speeds;
- @speeds = ($speedSize > 0) ? @speeds : ("15", "17", "20", "22", "25", "28", "30", "32", "35", "40", "45", "50");
-#@speeds = ($speedSize > 0) ? @speeds : ("15", "20");
+@speeds = ($speedSize > 0) ? @speeds : ("15", "17", "20", "22", "25", "28", "30", "35", "40", "45", "50");
 
 if (! -d "$output_directory") {
   mkdir "$output_directory";

--- a/text2speech.py
+++ b/text2speech.py
@@ -117,6 +117,9 @@ else:
     if language == "GERMAN":
         voice_id = "Vicki"
 
+    if language == "ROMANIAN":
+        voice_id = "Carmen"
+
     print("Using Voice: " + voice_id)
     cache_filename = cache_directory + language + "-standard-" + base_filename
     render(cache_filename, voice_id=voice_id, text_type=None, text=sentence)


### PR DESCRIPTION
I just added the standard carmen voice from polly and patched the regexes. Works fine, but the voice has an odd cadence at times. I had to encode_utf8() the filenames, containing romanian letters, before hashing, since they sha256 wouldn't work otherwise.